### PR TITLE
OSCのタイトルをちゃんとつけた

### DIFF
--- a/model/osc.rb
+++ b/model/osc.rb
@@ -21,8 +21,10 @@ module Plugin::OSCTimetable
     def self.[](url)
       osc = Plugin::OSCTimetable::OpenSourceConference.new(perma_link: url,
                                                            title: 'OSC')
-      Delayer::Deferred.new.next {
-        osc.dom.next { |doc|
+      Delayer::Deferred.new.next{
+        osc.dom.next{|doc|
+          osc.title = doc.css('title').text
+
           current_field = nil
           doc.css('#centerLcolumn .blockContent').first.children.each do |element|
             case element.name

--- a/osc_timetable.rb
+++ b/osc_timetable.rb
@@ -32,6 +32,7 @@ Plugin.create(:osc_timetable) do
       tab(tab_slug, osc.name) do
         temporary_tab
         set_deletable true
+        set_icon osc.user.icon
         timeline(:"osc_#{osc.idname}_timetables")
         active!
       end
@@ -50,6 +51,7 @@ Plugin.create(:osc_timetable) do
       tab(tab_slug, timetable.title) do
         temporary_tab
         set_deletable true
+        set_icon timetable.user.icon
         timeline :"osc_lectures_#{timetable.uri}"
         active!
       end


### PR DESCRIPTION
OSCのイベント名が単に「OSC」になっていたので、「オープンソースカンファレンス2017 Osaka」とか、Webページのタイトルバーからとってきた